### PR TITLE
remove heavily-used ISR triggers

### DIFF
--- a/frontend/app/[...path]/page.tsx
+++ b/frontend/app/[...path]/page.tsx
@@ -115,15 +115,15 @@ async function getPage(props: PageProps) {
   return pages[0];
 }
 
-export async function generateStaticParams(): Promise<{ path: string[] }[]> {
-  const pages = await client.fetch<{ slug: { current: string } }[]>(
-    `*[_type == 'page']{slug}`
-  );
+// export async function generateStaticParams(): Promise<{ path: string[] }[]> {
+//   const pages = await client.fetch<{ slug: { current: string } }[]>(
+//     `*[_type == 'page']{slug}`
+//   );
 
-  return pages.map((p) => ({
-    path: p.slug.current.split("/").filter(Boolean),
-  }));
-}
+//   return pages.map((p) => ({
+//     path: p.slug.current.split("/").filter(Boolean),
+//   }));
+// }
 
 export async function generateMetadata(props: PageProps) {
   const page = await getPage(props);

--- a/frontend/app/[...path]/page.tsx
+++ b/frontend/app/[...path]/page.tsx
@@ -104,8 +104,8 @@ async function getPage(props: PageProps) {
     }
   }
 }`,
-    {},
-    { next: { revalidate: 60 } }
+    {}
+    // { next: { revalidate: 60 } }
   );
 
   if (pages.length === 0) {

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -4,31 +4,14 @@ import "./globals.css";
 import { VisualEditing } from "next-sanity";
 import { draftMode } from "next/headers";
 import { DisableDraftMode } from "@/components/disable-draft-mode";
+import { GoogleTagManager } from "@/components/google-tag-manager";
+import { GOOGLE_TAG_MANAGER_ID } from "@/lib/constants";
 
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   title: "Saint Maria Goretti Catholic School",
   description: "Saint Maria Goretti Catholic School",
-};
-
-const Ga = (props: { gaId: string }) => {
-  const script = `
-window.dataLayer = window.dataLayer || [];
-function gtag(){dataLayer.push(arguments);}
-gtag('js', new Date());
-gtag('config', '${props.gaId}', {debug_mode: true});
-  `;
-
-  return (
-    <>
-      <script
-        async
-        src={`https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(props.gaId)}`}
-      ></script>
-      <script dangerouslySetInnerHTML={{ __html: script }}></script>
-    </>
-  );
 };
 
 export default function RootLayout({
@@ -42,7 +25,7 @@ export default function RootLayout({
         {children}
         {draftMode().isEnabled && <DisableDraftMode />}
         {draftMode().isEnabled && <VisualEditing />}
-        <Ga gaId="G-WW9E92XGYR" />
+        <GoogleTagManager gaId={GOOGLE_TAG_MANAGER_ID} />
       </body>
     </html>
   );

--- a/frontend/components/google-tag-manager.tsx
+++ b/frontend/components/google-tag-manager.tsx
@@ -1,0 +1,20 @@
+"use server";
+
+export async function GoogleTagManager(props: { gaId: string }) {
+  const script = `
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', '${props.gaId}');
+  `;
+
+  return (
+    <>
+      <script
+        async
+        src={`https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(props.gaId)}`}
+      ></script>
+      <script dangerouslySetInnerHTML={{ __html: script }}></script>
+    </>
+  );
+}

--- a/frontend/lib/constants.ts
+++ b/frontend/lib/constants.ts
@@ -1,3 +1,5 @@
+export const GOOGLE_TAG_MANAGER_ID = "G-WW9E92XGYR";
+
 export const PUBLIC_CALENDAR_URL =
   "https://outlook.office365.com/owa/calendar/e17014b3d3194bd28aeac7f6981e7637@smgschool.org/968a59748b1341389f01860bcc52b3694203663748153909325/calendar.html";
 


### PR DESCRIPTION
The use of ISR on every page is exceeding Vercel's ISR write quota for the Hobby plan. This _should_ avoid using ISR for most of those paths and directly server-render those pages instead. (We'll see how quickly we hit a quota with this technique)